### PR TITLE
Fix typo in requires_autograd example.

### DIFF
--- a/docs/source/notes/autograd.rst
+++ b/docs/source/notes/autograd.rst
@@ -30,7 +30,7 @@ performed in the subgraphs, where all Variables didn't require gradients.
     >>> x = Variable(torch.randn(5, 5))
     >>> y = Variable(torch.randn(5, 5))
     >>> z = Variable(torch.randn(5, 5), requires_grad=True)
-    >>> a = x + z
+    >>> a = x + y
     >>> a.requires_grad
     False
     >>> b = a + z


### PR DESCRIPTION
Line 34 computed a by adding 'x' to 'z', which implies 'a' requires_grad, but the result is False. Changing 'z' to 'y' in this example corrects the code and shows that a result does not require_grad whenever its inputs do not.